### PR TITLE
feat: add networkpolicy to allow ingress only from frontend

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -30,11 +30,12 @@ The installation can be customized by changing the following parameters via
 | `images.repositoryDirname`      | Prefix for image repos                                          | `ghcr.io/podtato-head`       |
 | `images.pullPolicy`             | Podtato Head Container pull policy                              | `IfNotPresent`               |
 | `images.pullSecrets`            | Podtato Head Pod pull secret                                    | ``                           |
-| `<service>.repositoryBasename`  | Leaf part of name of image repo for <service>                   | `entry`, `hat`, etc.         |
+| `<service>.repositoryBasename`  | Leaf part of name of image repo for <service>                   | `frontend`, `hat`, etc.      |
 | `<service>.tag`                 | Tag of image repo for <service>                                 | `0.1.0`                      |
 | `<service>.serviceType`         | Service type for <service>                                      | `LoadBalancer` for main      |
 | `<service>.servicePort`         | Service port for <service>                                      | `9000`-`9005`                |
 | `<service>.env`                 | Add "env:" entries on Deployments (ex: PODTATO_PART_NUMBER)     | `[]`                         |
+| `networkPolicy.enabled`         | Enable the NetworkPolicy                                        | `false`                      |
 | `serviceAccount.create`         | Whether or not to create dedicated service account              | `true`                       |
 | `serviceAccount.name`           | Name of the service account to use                              | `default`                    |
 | `serviceAccount.annotations`    | Annotations to add to a created service account                 | `{}`                         |

--- a/chart/templates/deployment-frontend.yaml
+++ b/chart/templates/deployment-frontend.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "podtato-head.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
+        role: frontend
     spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/chart/templates/deployment-hat.yaml
+++ b/chart/templates/deployment-hat.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "podtato-head.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
+        role: backend
     spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/chart/templates/deployment-left-arm.yaml
+++ b/chart/templates/deployment-left-arm.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "podtato-head.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
+        role: backend
     spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/chart/templates/deployment-left-leg.yaml
+++ b/chart/templates/deployment-left-leg.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "podtato-head.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
+        role: backend
     spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/chart/templates/deployment-right-arm.yaml
+++ b/chart/templates/deployment-right-arm.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "podtato-head.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
+        role: backend
     spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/chart/templates/deployment-right-leg.yaml
+++ b/chart/templates/deployment-right-leg.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         {{- include "podtato-head.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
+        role: backend
     spec:
       {{- with .Values.images.pullSecrets }}
       imagePullSecrets:

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-only-from-frontend
+spec:
+  podSelector:
+    matchLabels:
+      role: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: frontend
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,6 +59,12 @@ rightArm:
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 
+# Currently, the network policy restricts ingress traffic to
+# the backend components (hat, left-leg, right-leg, left-arm, right-arm)
+# by allowing traffic from the frontend component only.
+networkPolicy:
+  enabled: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/deploy/manifest.yaml
+++ b/deploy/manifest.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: podtato-head-frontend
+        role: frontend
     spec:
       containers:
       - name: podtato-head-frontend
@@ -72,6 +73,7 @@ spec:
     metadata:
       labels:
         app: podtato-head-left-arm
+        role: backend
     spec:
       containers:
         - name: podtato-head-left-arm
@@ -117,6 +119,7 @@ spec:
     metadata:
       labels:
         app: podtato-head-right-arm
+        role: backend
     spec:
       containers:
         - name: podtato-head-right-arm
@@ -162,6 +165,7 @@ spec:
     metadata:
       labels:
         app: podtato-head-left-leg
+        role: backend
     spec:
       containers:
         - name: podtato-head-left-leg
@@ -207,6 +211,7 @@ spec:
     metadata:
       labels:
         app: podtato-head-right-leg
+        role: backend
     spec:
       containers:
         - name: podtato-head-right-leg
@@ -252,6 +257,7 @@ spec:
     metadata:
       labels:
         app: podtato-head-hat
+        role: backend
     spec:
       containers:
         - name: podtato-head-hat
@@ -371,6 +377,23 @@ spec:
         port: 8080
         protocol: TCP
     type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-only-from-frontend
+  namespace: podtato-kubectl
+spec:
+  podSelector:
+    matchLabels:
+      role: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: frontend
 
 ---
 apiVersion: v1


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->


## 📑 Description
<!-- Add a brief description of the pr -->

Add network policy to allow ingress to backend only from frontend pod.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->